### PR TITLE
Update: auto view scroller

### DIFF
--- a/src/main/resources/public/src/main/webapp/app/feature/specificfilm/specificfilmController.js
+++ b/src/main/resources/public/src/main/webapp/app/feature/specificfilm/specificfilmController.js
@@ -30,6 +30,8 @@
             vm.videoEmbed = $sce.trustAsResourceUrl(vm.filmDat["trailer"]);
         });
 
+        // auto run
+        document.body.scrollTop = document.documentElement.scrollTop = 0;
     };
 
     angular.module("cinema").controller("sFController", ['filmLoader', '$state', '$sce', sFController]);


### PR DESCRIPTION
This updates the specific page to load in from the top of the page, rather than saving the view's position on load (potentially bottom of the film page).